### PR TITLE
Fix hashcode bug.

### DIFF
--- a/src/main/java/com/github/hcsp/collection/Person.java
+++ b/src/main/java/com/github/hcsp/collection/Person.java
@@ -50,7 +50,7 @@ public class Person {
     @Override
     public int hashCode() {
         int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (name != null ? name.hashCode() : 0);
+//        result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + age;
         return result;
     }


### PR DESCRIPTION
判断 equals 只调用 equals 方法，而判断 set.contains() 会先调用 hashCode()